### PR TITLE
Migrate from React Router to Tanstack Router

### DIFF
--- a/React-Router/client/package-lock.json
+++ b/React-Router/client/package-lock.json
@@ -17,6 +17,7 @@
         "@react-spring/web": "^9.7.3",
         "@stripe/react-stripe-js": "^2.4.0",
         "@stripe/stripe-js": "^2.3.0",
+        "@tanstack/react-router": "^1.8.3",
         "@types/react-transition-group": "^4.4.10",
         "feather": "^0.0.6",
         "graphql": "^16.8.1",
@@ -4532,6 +4533,66 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-2.3.0.tgz",
       "integrity": "sha512-iTwzjw1ORUR+1pH21+C/M05w+Jh5hAuE4QUei7Gnku65N7QpEaHtyVszYMYDBs6iNyLrD1tfQTSrjD6NkOA/ww=="
+    },
+    "node_modules/@tanstack/history": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/history/-/history-1.8.0.tgz",
+      "integrity": "sha512-RPukIMPedYLs3XySxcsD2PUAYnRh2GR1dKix/Rlaf8iIdl+fKH7nuX/V0+vYv7pSJZ6m/a/zmsX3Rm4xSyVB7g==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-router": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.8.3.tgz",
+      "integrity": "sha512-FrTFIuiyDhKemNBA1kegoS0aMkNT1qxlmoEIZ9uDlHJ+RBfYlnxwqzI3R3i2Ewj9FWsGf0h+TP0xNqj+1/wJYg==",
+      "dependencies": {
+        "@tanstack/history": "1.8.0",
+        "@tanstack/react-store": "^0.2.1",
+        "tiny-invariant": "^1.3.1",
+        "tiny-warning": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
+    },
+    "node_modules/@tanstack/react-store": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.2.1.tgz",
+      "integrity": "sha512-tEbMCQjbeVw9KOP/202LfqZMSNAVi6zYkkp1kBom8nFuMx/965Hzes3+6G6b/comCwVxoJU8Gg9IrcF8yRPthw==",
+      "dependencies": {
+        "@tanstack/store": "0.1.3",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
+    },
+    "node_modules/@tanstack/store": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.1.3.tgz",
+      "integrity": "sha512-GnolmC8Fr4mvsHE1fGQmR3Nm0eBO3KnZjDU0a+P3TeQNM/dDscFGxtA7p31NplQNW3KwBw4t1RVFmz0VeKLxcw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -9208,6 +9269,16 @@
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
+      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
+    },
+    "node_modules/tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
     "node_modules/title-case": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/title-case/-/title-case-3.0.3.tgz",
@@ -9479,6 +9550,14 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/utest": {

--- a/React-Router/client/package.json
+++ b/React-Router/client/package.json
@@ -20,6 +20,7 @@
     "@react-spring/web": "^9.7.3",
     "@stripe/react-stripe-js": "^2.4.0",
     "@stripe/stripe-js": "^2.3.0",
+    "@tanstack/react-router": "^1.8.3",
     "@types/react-transition-group": "^4.4.10",
     "feather": "^0.0.6",
     "graphql": "^16.8.1",

--- a/React-Router/client/src/components/Checkout/index.tsx
+++ b/React-Router/client/src/components/Checkout/index.tsx
@@ -11,7 +11,9 @@ import gql from "graphql-tag";
 import { useMutation } from "@apollo/client";
 import { useCart } from "../../lib/cart-state";
 import { CURRENT_USER_QUERY } from "../UserInfo";
-import { useNavigate } from "react-router-dom";
+// import { useNavigate } from "react-router-dom";
+import { useNavigate } from "@tanstack/react-router";
+
 import "./checkout-styles.css";
 import "./sick-button-styles.css";
 
@@ -74,7 +76,15 @@ function CheckoutForm() {
     console.log(`Finished with the order!!`);
     console.log(order);
     // 6. Change the page to view the order
-    navigate(`/orders/${order.data.checkout.id}`);
+
+    // react-router-implementation
+    // navigate(`/orders/${order.data.checkout.id}`);
+
+    // tanstack/react-router implementation
+    navigate({
+      to: "/orders/$orderId",
+      params: { orderId: order.data.checkout.id },
+    });
     // 7. Close the cart
     closeCart();
 

--- a/React-Router/client/src/components/CreateProduct/create-product.css
+++ b/React-Router/client/src/components/CreateProduct/create-product.css
@@ -61,6 +61,11 @@
     justify-content: center;
     align-items: center;
   }
+  img {
+    width: 475px;
+    height: 475px;
+    border-radius: 0.375rem;
+  }
 }
 
 @keyframes slideInFromLeft {

--- a/React-Router/client/src/components/CreateProduct/index.tsx
+++ b/React-Router/client/src/components/CreateProduct/index.tsx
@@ -1,4 +1,4 @@
-import { useMutation, gql } from "@apollo/client";
+import { useMutation } from "@apollo/client";
 import DisplayError from "../DisplayError";
 import { ALL_PRODUCTS_QUERY } from "../Products";
 import { useNavigate } from "react-router-dom";
@@ -23,7 +23,7 @@ export default function CreateProduct() {
   const {
     register,
     handleSubmit,
-    formState: { errors },
+    // formState: { errors },
     setValue,
   } = useForm({
     resolver: zodResolver(schema),

--- a/React-Router/client/src/components/Header/index.tsx
+++ b/React-Router/client/src/components/Header/index.tsx
@@ -1,4 +1,5 @@
-import { Link } from "react-router-dom";
+// import { Link } from "react-router-dom";
+import { Link } from "@tanstack/react-router";
 // import styled from "styled-components";
 import Nav from "../Nav";
 // import Cart from "./Cart";
@@ -10,7 +11,9 @@ export default function Header() {
     <header>
       <div className="bar">
         <h1>
-          <Link to="/">Sick Fits</Link>
+          <Link to="/" search={() => ({ page: 1 })}>
+            Sick Fits
+          </Link>
         </h1>
         <Nav />
       </div>

--- a/React-Router/client/src/components/Nav/index.tsx
+++ b/React-Router/client/src/components/Nav/index.tsx
@@ -1,4 +1,6 @@
-import { Link, useNavigate } from "react-router-dom";
+// import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "@tanstack/react-router";
+
 import { useUser } from "../UserInfo";
 import Profile from "../SignOut";
 import { useCart } from "../../lib/cart-state";
@@ -15,12 +17,14 @@ export default function Nav() {
   const { cartOpen, setCartOpen } = useCart();
   return (
     <ul className="nav__list">
-      <Link to="/">Products</Link>
+      <Link to="/" search={() => ({ page: 1 })}>
+        Products
+      </Link>
       <SessionAuth>
         <>
           <Link to="/sell">Sell</Link>
           <Link to="/orders">Orders</Link>
-          <Link to="/reset">Reset</Link>
+          {/* <Link to="/reset">Reset</Link> */}
           <Profile />
           <Dialog.Root open={cartOpen} onOpenChange={setCartOpen}>
             <Dialog.Trigger>
@@ -49,7 +53,7 @@ export default function Nav() {
       </SessionAuth>
       {!data?.user && (
         <>
-          <button type="button" onClick={() => navigate("/auth")}>
+          <button type="button" onClick={() => navigate({ to: "/auth" })}>
             Sign In
           </button>
         </>

--- a/React-Router/client/src/components/Pagination/index.tsx
+++ b/React-Router/client/src/components/Pagination/index.tsx
@@ -1,8 +1,10 @@
 import { useQuery, gql } from "@apollo/client";
-import { useSearchParams } from "react-router-dom";
+// import { useSearchParams } from "react-router-dom";
 import DisplayError from "../DisplayError";
 import { perPage } from "../../lib/constants";
 import "./pagination-styles.css";
+import { Link } from "@tanstack/react-router";
+import { productPage } from "../../routes/product-routes";
 
 export const PAGINATION_QUERY = gql(`
   query ProductsCountQuery {
@@ -11,7 +13,7 @@ export const PAGINATION_QUERY = gql(`
 `);
 
 export default function Pagination({ page }: { page: number }) {
-  const [_, setSearchParams] = useSearchParams();
+  // const [_, setSearchParams] = useSearchParams();
   const { error, loading, data } = useQuery(PAGINATION_QUERY);
   if (loading)
     return (
@@ -33,22 +35,27 @@ export default function Pagination({ page }: { page: number }) {
 
   return (
     <div className="pagination__styles">
-      <a
+      <Link
         aria-disabled={page <= 1}
-        onClick={() => setSearchParams({ page: String(page - 1) })}
+        from={productPage.fullPath}
+        to="/"
+        search={(prev) => ({ page: prev.page - 1 })}
+        // onClick={() => setSearchParams({ page: String(page - 1) })}
       >
         <span aria-disabled={page <= 1}>Prev</span>
-      </a>
+      </Link>
       <p>
         Page {page} of {pageCount}
       </p>
       <p>{count} Items Total</p>
-      <a
+      <Link
         aria-disabled={page >= pageCount}
-        onClick={() => setSearchParams({ page: String(page + 1) })}
+        from={productPage.fullPath}
+        search={(prev) => ({ page: prev.page + 1 })}
+        // onClick={() => setSearchParams({ page: String(page + 1) })}
       >
         <span aria-disabled={page >= pageCount}>Next</span>
-      </a>
+      </Link>
     </div>
   );
 }

--- a/React-Router/client/src/components/Product/index.tsx
+++ b/React-Router/client/src/components/Product/index.tsx
@@ -1,4 +1,5 @@
-import { Link } from "react-router-dom";
+// import { Link } from "react-router-dom";
+import { Link } from "@tanstack/react-router";
 import formatMoney from "../../lib/formatMoney";
 import DeleteProduct from "../DeleteProduct";
 import AddToCart from "../AddToCart";
@@ -14,13 +15,17 @@ export default function Product({ product }: SingleProduct) {
     <div className="item__styles">
       <img src={product?.photo?.image} alt={product.name} />
       <h3 className="product__title">
-        <Link to={`/products/${product.id}`}>{product.name}</Link>
+        <Link to="/products/$productId" params={{ productId: product.id }}>
+          {product.name}
+        </Link>
       </h3>
       <span className="price__tag">{formatMoney(product.price)}</span>
       <p>{product.description}</p>
       {/* TODO: Add buttons to edit and delete an item */}
       <div className="buttonList">
-        <Link to={product.id}>Edit</Link>
+        <Link to="/products/$productId" params={{ productId: product.id }}>
+          Edit
+        </Link>
         {/* id={product.id} */}
         <AddToCart id={product.id} />
         {/* id={product.id} */}

--- a/React-Router/client/src/components/SignOut/index.tsx
+++ b/React-Router/client/src/components/SignOut/index.tsx
@@ -1,6 +1,7 @@
 import { signOut } from "supertokens-auth-react/recipe/thirdpartyemailpassword";
 
-import { useNavigate } from "react-router-dom";
+// import { useNavigate } from "react-router-dom";
+import { useNavigate } from "@tanstack/react-router";
 
 export default function Profile() {
   const navigate = useNavigate();
@@ -9,7 +10,7 @@ export default function Profile() {
       <button
         onClick={async () => {
           signOut();
-          navigate("/");
+          navigate({ to: "/", search: { page: 1 } });
         }}
       >
         Sign Out

--- a/React-Router/client/src/lib/cart-state.tsx
+++ b/React-Router/client/src/lib/cart-state.tsx
@@ -8,7 +8,7 @@ const LocalStateContext = createContext<{
   openCart: () => void;
 }>({
   cartOpen: false,
-  setCartOpen: (value: boolean) => {},
+  setCartOpen: (_: boolean) => {},
   toggleCart: () => {},
   closeCart: () => {},
   openCart: () => {},

--- a/React-Router/client/src/lib/paginationField.ts
+++ b/React-Router/client/src/lib/paginationField.ts
@@ -53,7 +53,7 @@ export default function paginationField() {
       //f alse from here, (network request)
     },
     merge(existing: any, incoming: any, { args }: any) {
-      const { skip, take } = args;
+      const { skip } = args;
       // This runs when the apollo client comes back
       // from the network with our products
       console.log(`merging items from the network ${incoming.length}`);

--- a/React-Router/client/src/main.tsx
+++ b/React-Router/client/src/main.tsx
@@ -1,17 +1,17 @@
-import React from "react";
+// import React from "react";
 import ReactDOM from "react-dom/client";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
-import * as reactRouterDom from "react-router-dom";
+// import { BrowserRouter, Routes, Route } from "react-router-dom";
+// import * as reactRouterDom from "react-router-dom";
 import "./index.css";
 import { ApolloProviderWrapper } from "./components/ApolloProviderWrapper";
 import { SuperTokensWrapper } from "supertokens-auth-react";
-import { getSuperTokensRoutesForReactRouterDom } from "supertokens-auth-react/ui";
+import { canHandleRoute, getRoutingComponent } from "supertokens-auth-react/ui";
 import { ThirdPartyEmailPasswordPreBuiltUI } from "supertokens-auth-react/recipe/thirdpartyemailpassword/prebuiltui";
-import ErrorPage from "./error-page";
-import ProductsPage from "./pages/ProductsPage";
-import Root from "./pages/RootLayout";
-import SellPage from "./pages/SellPage";
-import SingleProductPage from "./pages/SingleProductPage";
+// import ErrorPage from "./error-page";
+// import ProductsPage from "./pages/ProductsPage";
+// import Root from "./pages/RootLayout";
+// import SellPage from "./pages/SellPage";
+// import SingleProductPage from "./pages/SingleProductPage";
 import SuperTokens from "supertokens-auth-react";
 import ThirdPartyEmailPassword, {
   Github,
@@ -23,9 +23,12 @@ import EmailPassword from "supertokens-auth-react/recipe/emailpassword";
 
 import Session from "supertokens-auth-react/recipe/session";
 import { CartStateProvider } from "./lib/cart-state";
-import OrdersPage from "./pages/OrdersPage";
-import OrderIdPage from "./pages/OrderIdPage";
-import AdminRoot from "./pages/AdminRoot";
+// import OrdersPage from "./pages/OrdersPage";
+// import OrderIdPage from "./pages/OrderIdPage";
+// import AdminRoot from "./pages/AdminRoot";
+// import { EmailPasswordPreBuiltUI } from "supertokens-auth-react/lib/build/recipe/emailpassword/prebuiltui";
+import { router } from "./routes";
+import { RouterProvider } from "@tanstack/react-router";
 
 SuperTokens.init({
   appInfo: {
@@ -52,12 +55,33 @@ SuperTokens.init({
   ],
 });
 
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: typeof router;
+  }
+}
+
 ReactDOM.createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
-    <SuperTokensWrapper>
-      <ApolloProviderWrapper>
-        <CartStateProvider>
-          <BrowserRouter>
+  <>
+    {/* <React.StrictMode> */}
+    {canHandleRoute([ThirdPartyEmailPasswordPreBuiltUI]) ? (
+      // This renders the login UI on the /auth route
+      getRoutingComponent([ThirdPartyEmailPasswordPreBuiltUI])
+    ) : (
+      <SuperTokensWrapper>
+        <ApolloProviderWrapper>
+          <CartStateProvider>
+            <RouterProvider router={router} />
+          </CartStateProvider>
+        </ApolloProviderWrapper>
+      </SuperTokensWrapper>
+    )}
+    {/* </React.StrictMode> */}
+  </>
+);
+
+{
+  /* <BrowserRouter>
             <Routes>
               {getSuperTokensRoutesForReactRouterDom(reactRouterDom, [
                 ThirdPartyEmailPasswordPreBuiltUI,
@@ -74,11 +98,9 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
                 <Route path="/orders/:orderId" element={<OrderIdPage />} />
               </Route>
               <Route path="/admin" element={<AdminRoot />} />
-              {/*Your app routes*/}
-            </Routes>
-          </BrowserRouter>
-        </CartStateProvider>
-      </ApolloProviderWrapper>
-    </SuperTokensWrapper>
-  </React.StrictMode>
-);
+              {/*Your app routes*/
+}
+{
+  /*  </Routes>
+          </BrowserRouter> */
+}

--- a/React-Router/client/src/pages/OrderIdPage.tsx
+++ b/React-Router/client/src/pages/OrderIdPage.tsx
@@ -2,7 +2,8 @@ import { useQuery } from "@apollo/client";
 import { gql } from "../__generated__";
 import DisplayError from "../components/DisplayError";
 import formatMoney from "../lib/formatMoney";
-import { useParams } from "react-router-dom";
+// import { useParams } from "react-router-dom";
+import { useParams } from "@tanstack/react-router";
 
 const SINGLE_ORDER_QUERY = gql(`
   query SINGLE_ORDER_QUERY($id: ID!) {
@@ -36,7 +37,7 @@ const SINGLE_ORDER_QUERY = gql(`
 // Once a user has order something that order id should forever exist unless they delete an account with all user info attached to it.
 // in that case, if they come back to this site they should still hit the error page, nor should they be allowed to navigate to an order page without being logged in.
 export default function SingleOrderPage() {
-  const params = useParams() as { orderId: string };
+  const params = useParams({ from: "/orders/$orderId" });
   const { data, error, loading } = useQuery(SINGLE_ORDER_QUERY, {
     variables: { id: params.orderId },
   });

--- a/React-Router/client/src/pages/OrdersPage.tsx
+++ b/React-Router/client/src/pages/OrdersPage.tsx
@@ -1,7 +1,8 @@
 import { useQuery } from "@apollo/client";
 import { gql } from "../__generated__";
 import { Order } from "../__generated__/graphql";
-import { Link } from "react-router-dom";
+// import { Link } from "react-router-dom";
+import { Link } from "@tanstack/react-router";
 import DisplayError from "../components/DisplayError";
 import formatMoney from "../lib/formatMoney";
 import "../components/additional-styles/order-item-styles.css";
@@ -50,9 +51,9 @@ export default function OrdersPage() {
       <h2>You have {data?.allOrders.length} orders!</h2>
       <ul className="order__list__styles">
         {data?.allOrders.map((order) => (
-          <li className="order__item__styles">
-            <Link to={`/orders/${order.id}`}>
-              <a>
+          <li key={order.id} className="order__item__styles">
+            <Link to="/orders/$orderId" params={{ orderId: order.id }}>
+              <span>
                 <div className="order-meta">
                   <p>{countItemsInAnOrder(order)} Items</p>
                   <p>
@@ -70,7 +71,7 @@ export default function OrdersPage() {
                     />
                   ))}
                 </div>
-              </a>
+              </span>
             </Link>
           </li>
         ))}

--- a/React-Router/client/src/pages/ProductsPage.tsx
+++ b/React-Router/client/src/pages/ProductsPage.tsx
@@ -1,10 +1,16 @@
-import { useSearchParams } from "react-router-dom";
+// import { useSearchParams } from "react-router-dom";
+import { useSearch } from "@tanstack/react-router";
 import Pagination from "../components/Pagination";
 import Products from "../components/Products";
+import { productPage } from "../routes/product-routes";
 
 export default function ProductsPage() {
-  const [searchParams, _] = useSearchParams();
-  const page = Number(searchParams.get("page")) || 1;
+  // const [searchParams, _] = useSearchParams();
+  const { page } = useSearch({
+    from: productPage.fullPath,
+  });
+
+  console.log("page", page);
 
   return (
     <div>

--- a/React-Router/client/src/pages/RootLayout.tsx
+++ b/React-Router/client/src/pages/RootLayout.tsx
@@ -1,4 +1,5 @@
-import { Outlet } from "react-router";
+// import { Outlet } from "react-router";
+import { Outlet } from "@tanstack/react-router";
 import Header from "../components/Header";
 import "./root.css";
 

--- a/React-Router/client/src/routes/auth-route.tsx
+++ b/React-Router/client/src/routes/auth-route.tsx
@@ -1,0 +1,7 @@
+import { Route } from "@tanstack/react-router";
+import { rootRoute } from "./root-route";
+
+export const authRoute = new Route({
+  getParentRoute: () => rootRoute,
+  path: "/auth",
+});

--- a/React-Router/client/src/routes/index.tsx
+++ b/React-Router/client/src/routes/index.tsx
@@ -1,0 +1,17 @@
+import { Router } from "@tanstack/react-router";
+import { rootRoute } from "./root-route";
+import { productIdPage, productPage } from "./product-routes";
+import { allOrdersPage, orderDetailPage } from "./order-routes";
+import { sellRoute } from "./sell-route";
+import { authRoute } from "./auth-route";
+
+const routeTree = rootRoute.addChildren([
+  productPage,
+  productIdPage,
+  allOrdersPage,
+  orderDetailPage,
+  sellRoute,
+  authRoute,
+]);
+
+export const router = new Router({ routeTree });

--- a/React-Router/client/src/routes/order-routes.tsx
+++ b/React-Router/client/src/routes/order-routes.tsx
@@ -1,0 +1,16 @@
+import { Route } from "@tanstack/react-router";
+import { rootRoute } from "./root-route";
+import OrdersPage from "../pages/OrdersPage";
+import OrderIdPage from "../pages/OrderIdPage";
+
+export const allOrdersPage = new Route({
+  getParentRoute: () => rootRoute,
+  path: "/orders",
+  component: () => <OrdersPage />,
+});
+
+export const orderDetailPage = new Route({
+  getParentRoute: () => rootRoute,
+  path: "/orders/$orderId",
+  component: () => <OrderIdPage />,
+});

--- a/React-Router/client/src/routes/product-routes.tsx
+++ b/React-Router/client/src/routes/product-routes.tsx
@@ -1,0 +1,26 @@
+import { Route } from "@tanstack/react-router";
+import { rootRoute } from "./root-route";
+import ProductsPage from "../pages/ProductsPage";
+import SingleProductPage from "../pages/SingleProductPage";
+import * as z from "zod";
+
+const productSearchSchema = z.object({
+  page: z.number().catch(1),
+});
+
+export const productPage = new Route({
+  getParentRoute: () => rootRoute,
+  path: "/",
+  validateSearch: productSearchSchema,
+  component: () => {
+    return <ProductsPage />;
+  },
+});
+
+export const productIdPage = new Route({
+  getParentRoute: () => rootRoute,
+  path: "/products/$productId",
+  component: () => {
+    return <SingleProductPage />;
+  },
+});

--- a/React-Router/client/src/routes/root-route.tsx
+++ b/React-Router/client/src/routes/root-route.tsx
@@ -1,0 +1,6 @@
+import { RootRoute } from "@tanstack/react-router";
+import RootLayout from "../pages/RootLayout";
+
+export const rootRoute = new RootRoute({
+  component: () => <RootLayout />,
+});

--- a/React-Router/client/src/routes/sell-route.tsx
+++ b/React-Router/client/src/routes/sell-route.tsx
@@ -1,0 +1,9 @@
+import { Route } from "@tanstack/react-router";
+import SellPage from "../pages/SellPage";
+import { rootRoute } from "./root-route";
+
+export const sellRoute = new Route({
+  getParentRoute: () => rootRoute,
+  path: "/sell",
+  component: () => <SellPage />,
+});

--- a/React-Router/server/tsconfig.json
+++ b/React-Router/server/tsconfig.json
@@ -5,7 +5,7 @@
     "target": "es2020",
     "moduleResolution": "node",
     "esModuleInterop": true,
-    "module": "commonjs"
+    "module": "CommonJS"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Here are the main migrations: 

- Routes: Created manual routes with Tanstack Router's `new Route` method. Registered those routes
- Reoriented root of app to move from Supertoken & React Router Dom to a normal Supertoken setup with React. 
- Replace Routes in `main.tsx` with Tanstack Router's `RouterProvider and passed the router
- Replaced all instances of React Router `Link` components and `useNavigate` hooks with the Tanstack Router equivalent. 
- Removed React Router's `useSearchParams` hook and used Tanstack Router's `Link` component search prop along with a `validateSearch` property on the `ProductsPage` route. 
     - Allowed me to make use of Tanstack Router's `Link` component search state and changed the pagination state with a link component. 
- Replace `Outlet` imports to be from Tanstack Router
- Add params prop on Tanstack Router Link components
- Use the `useSearch` function to read search from a specific routes full path to get a query param value for orders. 

## TODO's: 

- [ ] - remove auth route since I added it to make the router's typesafety-ness happy. Doesn't allow me to actually go to the Auth route that Supertokens has set up
- [ ] - see if I can use the history state for products and if I go to another route, like orders, but click back to products, it should find that history state rather than resetting it to show the first two products.